### PR TITLE
Add support for vue-property-decorator in Vue 3

### DIFF
--- a/examples/vue3/package.json
+++ b/examples/vue3/package.json
@@ -11,7 +11,9 @@
     "pug-plain-loader": "^1.0.0",
     "vee-validate": "^3.4.10",
     "vue": "^3.0.0",
-    "vue-cli-plugin-import-components": "../../"
+    "vue-class-component": "8.0.0-rc.1",
+    "vue-cli-plugin-import-components": "../../",
+    "vue-property-decorator": "10.0.0-rc.3"
   },
   "devDependencies": {
     "@vue/cli-service": "~4.5.0",

--- a/examples/vue3/src/App.vue
+++ b/examples/vue3/src/App.vue
@@ -68,6 +68,15 @@
 
     <tr>
       <td>
+        <code>PropertyDecoratorComponent.vue</code>
+      </td>
+      <td>
+        <PropertyDecoratorComponent/>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         <code>Nested Global Component</code>
       </td>
       <td>

--- a/examples/vue3/src/ui/PropertyDecoratorComponent.vue
+++ b/examples/vue3/src/ui/PropertyDecoratorComponent.vue
@@ -1,0 +1,14 @@
+<template>
+<div>
+  <component-a/>
+  <component-b/>
+  <component-c/>
+</div>
+</template>
+
+<script>
+import {Vue} from 'vue-property-decorator'
+
+export default class PropertyDecoratorComponent extends Vue {
+}
+</script>

--- a/examples/vue3/yarn.lock
+++ b/examples/vue3/yarn.lock
@@ -6948,8 +6948,13 @@ void-elements@^3.1.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
   integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
 
+vue-class-component@8.0.0-rc.1:
+  version "8.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-8.0.0-rc.1.tgz#db692cd97656eb9a08206c03d0b7398cdb1d9420"
+  integrity sha512-w1nMzsT/UdbDAXKqhwTmSoyuJzUXKrxLE77PCFVuC6syr8acdFDAq116xgvZh9UCuV0h+rlCtxXolr3Hi3HyPQ==
+
 vue-cli-plugin-import-components@../../:
-  version "1.0.2"
+  version "1.2.0"
   dependencies:
     "@vue/cli-shared-utils" "^4.5.13"
     globby "^11.0.4"
@@ -6981,6 +6986,11 @@ vue-loader@^15.9.2:
     loader-utils "^1.1.0"
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
+
+vue-property-decorator@10.0.0-rc.3:
+  version "10.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-10.0.0-rc.3.tgz#bb0cb2c7c31dc41149eb432f2104fb82dc3d95be"
+  integrity sha512-EGqjf8Lq+kTausZzfLB1ynWOcyay8ZLAc5p2VlKGEX2q+BjYw84oZxr6IcdwuxGIdNmriZqPUX6AlAluBdnbEg==
 
 vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.2"

--- a/src/vue3/injectComponents.ts
+++ b/src/vue3/injectComponents.ts
@@ -13,7 +13,7 @@ export default function injectComponents(source: string, components: Component[]
       injectImports('script', components)}`
 
   // script.options is used by vue-property-decorator
-  newContent += `if (script.options) { ${injectImports('script.options', components)}}`
+  newContent += `if ('__vccOpts' in script) { script.__o = script.__o || {}; ${injectImports('script.__o', components)}}`
 
   const hotReload = source.indexOf('/* hot reload */')
   if (hotReload > -1)


### PR DESCRIPTION
Detect if it uses [`__vccOpts`](https://github.com/vuejs/vue-class-component/blob/70680d78ed61ac57f27ed193fc69c80d90faf4fe/src/vue.ts#L194), and if so, add to [`_o`](https://github.com/vuejs/vue-class-component/blob/70680d78ed61ac57f27ed193fc69c80d90faf4fe/src/vue.ts#L208), because it no longer uses `.options` like it did with Vue 2.